### PR TITLE
Minor format! cleanup

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,8 +35,8 @@ fn main() {
 }
 
 fn generate_ffi(static_link: bool, modern_sqlite: bool) {
-    println!("cargo:rerun-if-changed={}", BINDGEN_OUTPUT);
-    let mut file = File::open(format!("{}", BINDGEN_OUTPUT)).expect(BINDGEN_OUTPUT);
+    println!("cargo:rerun-if-changed={BINDGEN_OUTPUT}");
+    let mut file = File::open(format!("{BINDGEN_OUTPUT}")).expect(BINDGEN_OUTPUT);
     let mut content = String::new();
     file.read_to_string(&mut content).unwrap();
 
@@ -162,7 +162,7 @@ fn generate_ffi(static_link: bool, modern_sqlite: bool) {
     };
 
     let tokens = TokenStream::from(result);
-    let src = format!("{}", tokens);
+    let src = format!("{tokens}");
     let formatted = rustfmt(src).unwrap();
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("linking.rs");
@@ -190,12 +190,12 @@ fn extract_method(ty: &syn::Type) -> Option<&syn::TypeBareFn> {
 
 fn rustfmt(input: String) -> Result<String, String> {
     let rustfmt =
-        which::which("rustfmt").map_err(|e| format!("unable to locate rustfmt: {:?}", e))?;
+        which::which("rustfmt").map_err(|e| format!("unable to locate rustfmt: {e:?}"))?;
     let mut rustfmt_child = std::process::Command::new(rustfmt)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .spawn()
-        .map_err(|e| format!("failed to spawn rustfmt: {:?}", e))?;
+        .map_err(|e| format!("failed to spawn rustfmt: {e:?}"))?;
     let mut stdin = rustfmt_child.stdin.take().unwrap();
 
     ::std::thread::spawn(move || {
@@ -206,5 +206,5 @@ fn rustfmt(input: String) -> Result<String, String> {
     if output.status.code() != Some(0) {
         return Err(format!("rustfmt exited with {:?}", output.status.code()));
     }
-    String::from_utf8(output.stdout).map_err(|e| format!("rustfmt returned invalid utf-8: {:?}", e))
+    String::from_utf8(output.stdout).map_err(|e| format!("rustfmt returned invalid utf-8: {e:?}"))
 }

--- a/sqlite3_ext_macro/src/lib.rs
+++ b/sqlite3_ext_macro/src/lib.rs
@@ -394,7 +394,7 @@ pub fn sqlite3_ext_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
     let opts_name = Ident::new(
-        &format!("{}_opts", ident).to_case(Case::UpperSnake),
+        &format!("{ident}_opts").to_case(Case::UpperSnake),
         Span::call_site(),
     );
     let mut opts = quote! {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -177,8 +177,8 @@ impl Connection {
             while !stmt.is_null() {
                 let cstr = CStr::from_ptr(ffi::sqlite3_sql(stmt)).to_str();
                 match cstr {
-                    Ok(cstr) => eprintln!("=> {}", cstr),
-                    Err(e) => eprintln!("{:?}: invalid SQL: {}", stmt, e),
+                    Ok(cstr) => eprintln!("=> {cstr}"),
+                    Err(e) => eprintln!("{stmt:?}: invalid SQL: {e}"),
                 }
                 stmt = ffi::sqlite3_next_stmt(self.as_mut_ptr(), stmt);
             }
@@ -268,9 +268,9 @@ impl Drop for Database {
     fn drop(&mut self) {
         if let Err(e) = self._close() {
             if panicking() {
-                eprintln!("Error while closing SQLite connection: {:?}", e);
+                eprintln!("Error while closing SQLite connection: {e:?}");
             } else {
-                panic!("Error while closing SQLite connection: {:?}", e);
+                panic!("Error while closing SQLite connection: {e:?}");
             }
         }
     }

--- a/src/function/context.rs
+++ b/src/function/context.rs
@@ -214,7 +214,7 @@ to_context_result! {
             Error::Sqlite(code, None) => ffi::sqlite3_result_error_code(ctx, code),
             Error::NoChange => (),
             _ => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 let msg = msg.as_bytes();
                 let len = msg.len();
                 ffi::sqlite3_result_error(ctx, msg.as_ptr() as _, len as _);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -124,9 +124,9 @@ impl Drop for Transaction<'_> {
         if self.state != TransactionState::Inactive {
             if let Err(e) = self.rollback_mut() {
                 if std::thread::panicking() {
-                    eprintln!("Error while closing SQLite transaction: {:?}", e);
+                    eprintln!("Error while closing SQLite transaction: {e:?}");
                 } else {
-                    panic!("Error while closing SQLite transaction: {:?}", e);
+                    panic!("Error while closing SQLite transaction: {e:?}");
                 }
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,7 +95,7 @@ impl Error {
             | e @ Error::Module(_)
             | e @ Error::NoChange => {
                 if !msg.is_null() {
-                    if let Ok(s) = ffi::str_to_sqlite3(&format!("{}", e)) {
+                    if let Ok(s) = ffi::str_to_sqlite3(&format!("{e}")) {
                         unsafe { *msg = s };
                     }
                 }
@@ -120,7 +120,7 @@ impl From<&str> for Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Sqlite(_, Some(desc)) => write!(f, "{}", desc),
+            Error::Sqlite(_, Some(desc)) => write!(f, "{desc}"),
             Error::Sqlite(i, None) => {
                 let errstr: Result<&str> = sqlite3_require_version!(3_007_015, unsafe {
                     std::ffi::CStr::from_ptr(ffi::sqlite3_errstr(*i))
@@ -128,13 +128,13 @@ impl std::fmt::Display for Error {
                         .map_err(Error::Utf8Error)
                 });
                 match errstr {
-                    Ok(s) => write!(f, "{}", s),
-                    _ => write!(f, "SQLite error {}", i),
+                    Ok(s) => write!(f, "{s}"),
+                    _ => write!(f, "SQLite error {i}"),
                 }
             }
             Error::Utf8Error(e) => e.fmt(f),
             Error::NulError(e) => e.fmt(f),
-            Error::Module(s) => write!(f, "{}", s),
+            Error::Module(s) => write!(f, "{s}"),
             Error::VersionNotSatisfied(v) => write!(
                 f,
                 "requires SQLite version {}.{}.{} or above",

--- a/src/value/blob.rs
+++ b/src/value/blob.rs
@@ -149,7 +149,7 @@ mod test {
     #[test]
     fn debug() {
         let blob = Blob::from([1, 2, 3, 4]);
-        assert_eq!(format!("{:?}", blob), "Blob([1, 2, 3, 4])");
+        assert_eq!(format!("{blob:?}"), "Blob([1, 2, 3, 4])");
     }
 
     #[test]

--- a/src/vtab/module.rs
+++ b/src/vtab/module.rs
@@ -67,7 +67,7 @@ where
         T: TransactionVTab<'vtab>,
     {
         self.with_initial_transaction();
-        let mut m = self.module();
+        let m = self.module();
         m.xBegin = Some(stubs::vtab_begin::<T>);
         m.xSync = Some(stubs::vtab_sync::<T>);
         m.xCommit = Some(stubs::vtab_commit::<T>);


### PR DESCRIPTION
Ran clippy to fix format inlining:

```
cargo clippy --allow-dirty --fix -- -A clippy::all -W clippy::uninlined_format_args
```

Overall, looks like great code, but I am really worried about using it in production due to the "non-standard" license.  Could you do the standard `"MIT OR APACHE-2.0"` please?  Many projects employ auto-validators that wouldn't allow this one :(