### PR TITLE
Cross compilation fixes

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,7 +8,7 @@ use std::{
     ffi::{CStr, CString},
     mem::MaybeUninit,
     ops::{Deref, DerefMut},
-    os::raw::c_int,
+    os::raw::{c_char, c_int},
     path::Path,
     ptr::null_mut,
     thread::panicking,
@@ -118,7 +118,7 @@ impl Connection {
             let guard = self.lock();
             LoadExtensionGuard::new(&guard)?;
             unsafe {
-                let mut err: MaybeUninit<*mut i8> = MaybeUninit::uninit();
+                let mut err: MaybeUninit<*mut c_char> = MaybeUninit::uninit();
                 let path = CString::new(path)?;
                 let entry = match entry {
                     Some(s) => Some(CString::new(s)?),

--- a/src/function/stubs.rs
+++ b/src/function/stubs.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use std::{
     cmp::Ordering,
-    ffi::{c_void, CStr},
+    ffi::{c_char, c_void, CStr},
     slice,
     str::from_utf8_unchecked,
 };
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn collation_needed<F: Fn(&str)>(
     user_data: *mut c_void,
     _db: *mut ffi::sqlite3,
     _text_rep: i32,
-    name: *const i8,
+    name: *const c_char,
 ) {
     let func = &*(user_data as *const F);
     let name = match CStr::from_ptr(name).to_str() {

--- a/src/value/passed_ref.rs
+++ b/src/value/passed_ref.rs
@@ -1,6 +1,7 @@
 use std::any::{Any, TypeId};
+use std::os::raw::c_char;
 
-pub(crate) const POINTER_TAG: *const i8 = c"sqlite3_ext:PassedRef".as_ptr() as _;
+pub(crate) const POINTER_TAG: *const c_char = c"sqlite3_ext:PassedRef".as_ptr() as _;
 
 /// Pass arbitrary values through SQLite.
 ///

--- a/src/vtab/stubs.rs
+++ b/src/vtab/stubs.rs
@@ -2,7 +2,7 @@ use super::super::{ffi, value::*, vtab::*, Connection};
 use std::{
     ffi::{CStr, CString},
     marker::PhantomData,
-    os::raw::{c_int, c_void},
+    os::raw::{c_char, c_int, c_void},
     ptr, slice,
 };
 
@@ -28,9 +28,9 @@ macro_rules! vtab_connect {
             db: *mut ffi::sqlite3,
             module: *mut c_void,
             argc: i32,
-            argv: *const *const i8,
+            argv: *const *const c_char,
             p_vtab: *mut *mut ffi::sqlite3_vtab,
-            err_msg: *mut *mut i8,
+            err_msg: *mut *mut c_char,
         ) -> c_int {
             let conn = &*(db as *mut Connection);
             let module = module::Handle::<'vtab, T>::from_ptr(module);
@@ -79,9 +79,9 @@ pub unsafe extern "C" fn vtab_connect_transaction<'vtab, T: TransactionVTab<'vta
     db: *mut ffi::sqlite3,
     module: *mut c_void,
     argc: i32,
-    argv: *const *const i8,
+    argv: *const *const c_char,
     p_vtab: *mut *mut ffi::sqlite3_vtab,
-    err_msg: *mut *mut i8,
+    err_msg: *mut *mut c_char,
 ) -> c_int {
     match vtab_connect::<T>(db, module, argc, argv, p_vtab, err_msg) {
         ffi::SQLITE_OK => (),
@@ -97,9 +97,9 @@ pub unsafe extern "C" fn vtab_create_transaction<
     db: *mut ffi::sqlite3,
     module: *mut c_void,
     argc: i32,
-    argv: *const *const i8,
+    argv: *const *const c_char,
     p_vtab: *mut *mut ffi::sqlite3_vtab,
-    err_msg: *mut *mut i8,
+    err_msg: *mut *mut c_char,
 ) -> c_int {
     match vtab_create::<T>(db, module, argc, argv, p_vtab, err_msg) {
         ffi::SQLITE_OK => (),
@@ -178,7 +178,7 @@ pub unsafe extern "C" fn vtab_destroy<'vtab, T: CreateVTab<'vtab> + 'vtab>(
 pub unsafe extern "C" fn vtab_filter<'vtab, T: VTab<'vtab> + 'vtab>(
     cursor: *mut ffi::sqlite3_vtab_cursor,
     index_num: i32,
-    index_str: *const i8,
+    index_str: *const c_char,
     argc: i32,
     argv: *mut *mut ffi::sqlite3_value,
 ) -> c_int {
@@ -260,7 +260,7 @@ pub unsafe extern "C" fn vtab_update<'vtab, T: UpdateVTab<'vtab> + 'vtab>(
 pub unsafe extern "C" fn vtab_find_function<'vtab, T: FindFunctionVTab<'vtab> + 'vtab>(
     vtab: *mut ffi::sqlite3_vtab,
     n_args: c_int,
-    name: *const i8,
+    name: *const c_char,
     p_func: *mut Option<
         unsafe extern "C" fn(*mut ffi::sqlite3_context, c_int, *mut *mut ffi::sqlite3_value),
     >,
@@ -329,7 +329,7 @@ pub unsafe extern "C" fn vtab_rollback<'vtab, T: TransactionVTab<'vtab> + 'vtab>
 
 pub unsafe extern "C" fn vtab_rename<'vtab, T: RenameVTab<'vtab> + 'vtab>(
     vtab: *mut ffi::sqlite3_vtab,
-    name: *const i8,
+    name: *const c_char,
 ) -> c_int {
     let vtab = &mut *(vtab.cast::<VTabHandle<T>>());
     let name = match CStr::from_ptr(name).to_str() {
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn vtab_rollback_to<'vtab, T: TransactionVTab<'vtab> + 'vt
 
 #[cfg(modern_sqlite)]
 pub unsafe extern "C" fn vtab_shadow_name<'vtab, T: CreateVTab<'vtab> + 'vtab>(
-    name: *const i8,
+    name: *const c_char,
 ) -> c_int {
     let name = CStr::from_ptr(name).to_bytes();
     for candidate in T::SHADOW_NAMES {


### PR DESCRIPTION
This change swaps out a bunch of `i8` pointers with `c_char` pointers wherever the type refers to a C string. aarch64 uses `u8` pointers for strings, and this seems to be the only change needed for cross compile to work (likely also native compilation, but I have not tested this).