### PR TITLE
Fix: Implement `path_to_cstring` in windows

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -198,6 +198,12 @@ fn path_to_cstring(path: &Path) -> CString {
     CString::new(path.as_os_str().as_bytes()).unwrap()
 }
 
+#[cfg(windows)]
+fn path_to_cstring(path: &Path)
+-> CString {
+    CString::new(path.to_str().expect("path must be valid UTF-8")).unwrap()
+}
+
 /// Represents an owned connection to an SQLite database.
 ///
 /// This struct is an owned version of [Connection]. When this struct is dropped, it will close


### PR DESCRIPTION
Hey Ryan, really cool work here.

I ran into an issue when trying to compile an extension in a windows environment:

```sh
error[E0425]: cannot find function `path_to_cstring` in this scope
   --> C:\Users\runneradmin\.cargo\git\checkouts\sqlite3_ext-331632534b0fe16e\f1a63f6\src\connection.rs:211:24
    |
211 |         let filename = path_to_cstring(path.as_ref());
    |                        ^^^^^^^^^^^^^^^ not found in this scope
    |
```

`path_to_cstring` was defined only under `#[cfg(unix)]`. The downstream call causes a compile error on Windows. This adds a `#[cfg(windows)]` implementation using `path.to_str()`.


Demo repo showing the error and the fix applied via `[patch.crates-io]` (can be seen via the GH Actions):
https://github.com/arianfarid/sqlite3_ext_demo
