### PR TITLE
fix: improve path_to_cstring for Unix and non-Unix systems

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -193,10 +193,13 @@ impl std::fmt::Debug for Connection {
 }
 
 fn path_to_cstring(path: &Path) -> CString {
-    if cfg!(unix) {
+    #[cfg(unix)]
+    {
         use std::os::unix::ffi::OsStrExt;
         CString::new(path.as_os_str().as_bytes()).unwrap()
-    } else {
+    }
+    #[cfg(not(unix))]
+    {
         CString::new(path.to_str().expect("path is not valid UTF-8")).unwrap()
     }
 }


### PR DESCRIPTION
#8 